### PR TITLE
Add multiple AuthPlugin support and some fixes.

### DIFF
--- a/checkstyle.header
+++ b/checkstyle.header
@@ -1,16 +1,17 @@
-/\*\*
- \* personium.io
- \* Copyright .*
- \*
- \* Licensed under the Apache License, Version 2.0 \(the "License"\);
- \* you may not use this file except in compliance with the License.
- \* You may obtain a copy of the License at
- \*
- \*     http://www.apache.org/licenses/LICENSE-2.0
- \*
- \* Unless required by applicable law or agreed to in writing, software
- \* distributed under the License is distributed on an "AS IS" BASIS,
- \* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- \* See the License for the specific language governing permissions and
- \* limitations under the License.
- \*/
+/\*\*$
+ \* Personium$
+ \* Copyright (\d\d\d\d-)?\d\d\d\d Personium Project Authors$
+ \* - .*$
+ \*$
+ \* Licensed under the Apache License, Version 2\.0 \(the "License"\);$
+ \* you may not use this file except in compliance with the License\.$
+ \* You may obtain a copy of the License at$
+ \*$
+ \*     http://www.apache.org/licenses/LICENSE-2.0$
+ \*$
+ \* Unless required by applicable law or agreed to in writing, software$
+ \* distributed under the License is distributed on an "AS IS" BASIS,$
+ \* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.$
+ \* See the License for the specific language governing permissions and$
+ \* limitations under the License\.$
+ \*/$

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
             <id>central</id>
             <name>Maven Repository Switchboard</name>
             <layout>default</layout>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>

--- a/src/main/java/io/personium/plugin/base/Plugin.java
+++ b/src/main/java/io/personium/plugin/base/Plugin.java
@@ -1,6 +1,7 @@
 /**
- * personium.io
- * Copyright 2017 FUJITSU LIMITED
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/personium/plugin/base/PluginConfig.java
+++ b/src/main/java/io/personium/plugin/base/PluginConfig.java
@@ -1,6 +1,7 @@
 /**
- * personium.io
- * Copyright 2017 FUJITSU LIMITED
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/personium/plugin/base/PluginException.java
+++ b/src/main/java/io/personium/plugin/base/PluginException.java
@@ -1,6 +1,7 @@
 /**
- * personium.io
- * Copyright 2017 FUJITSU LIMITED
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/personium/plugin/base/PluginLog.java
+++ b/src/main/java/io/personium/plugin/base/PluginLog.java
@@ -1,6 +1,7 @@
 /**
- * personium.io
- * Copyright 2017 FUJITSU LIMITED
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/personium/plugin/base/PluginMessageUtils.java
+++ b/src/main/java/io/personium/plugin/base/PluginMessageUtils.java
@@ -77,18 +77,16 @@ public abstract class PluginMessageUtils {
     private static Properties doLoad(String file) {
         Properties prop = new Properties();
         prop.clear();
-        InputStream is = PluginConfig.class.getClassLoader().getResourceAsStream(file);
-        try {
+
+        try (InputStream is = PluginConfig.class.getClassLoader().getResourceAsStream(file)) {
+            if (is == null) {
+                throw new RuntimeException("Property file is not found: " + file);
+            }
             prop.load(is);
         } catch (IOException e) {
             throw new RuntimeException("failed to load config!", e);
-        } finally {
-            try {
-                is.close();
-            } catch (IOException e) {
-                throw new RuntimeException("failed to close config stream", e);
-            }
         }
+
         return prop;
     }
 

--- a/src/main/java/io/personium/plugin/base/PluginMessageUtils.java
+++ b/src/main/java/io/personium/plugin/base/PluginMessageUtils.java
@@ -1,6 +1,7 @@
 /**
- * personium.io
- * Copyright 2017 FUJITSU LIMITED
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/personium/plugin/base/auth/AuthConst.java
+++ b/src/main/java/io/personium/plugin/base/auth/AuthConst.java
@@ -1,6 +1,7 @@
 /**
- * personium.io
- * Copyright 2017 FUJITSU LIMITED
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/personium/plugin/base/auth/AuthPlugin.java
+++ b/src/main/java/io/personium/plugin/base/auth/AuthPlugin.java
@@ -1,6 +1,7 @@
 /**
- * personium.io
- * Copyright 2017 FUJITSU LIMITED
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +24,6 @@ import io.personium.plugin.base.Plugin;
 
 /**
  * AuthPlugin.
- *
  */
 public interface AuthPlugin extends Plugin {
     /**

--- a/src/main/java/io/personium/plugin/base/auth/AuthPluginException.java
+++ b/src/main/java/io/personium/plugin/base/auth/AuthPluginException.java
@@ -1,6 +1,7 @@
 /**
- * personium.io
- * Copyright 2018 FUJITSU LIMITED
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/personium/plugin/base/auth/AuthPluginLoader.java
+++ b/src/main/java/io/personium/plugin/base/auth/AuthPluginLoader.java
@@ -1,0 +1,14 @@
+package io.personium.plugin.base.auth;
+
+import java.util.ArrayList;
+
+/**
+ * Interface of providing multiple AuthPlugin instance.
+ */
+public interface AuthPluginLoader {
+    /**
+     * Instanciate Multiple AuthPlugin
+     * @return
+     */
+    ArrayList<AuthPlugin> loadInstances();
+}

--- a/src/main/java/io/personium/plugin/base/auth/AuthPluginLoader.java
+++ b/src/main/java/io/personium/plugin/base/auth/AuthPluginLoader.java
@@ -17,7 +17,7 @@
  */
 package io.personium.plugin.base.auth;
 
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Interface of providing multiple AuthPlugin instance.

--- a/src/main/java/io/personium/plugin/base/auth/AuthPluginLoader.java
+++ b/src/main/java/io/personium/plugin/base/auth/AuthPluginLoader.java
@@ -1,3 +1,20 @@
+/**
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.personium.plugin.base.auth;
 
 import java.util.ArrayList;
@@ -7,8 +24,8 @@ import java.util.ArrayList;
  */
 public interface AuthPluginLoader {
     /**
-     * Instanciate Multiple AuthPlugin
-     * @return
+     * Instanciate Multiple AuthPlugin.
+     * @return ArrayList of AuthPlugin
      */
     ArrayList<AuthPlugin> loadInstances();
 }

--- a/src/main/java/io/personium/plugin/base/auth/AuthPluginLoader.java
+++ b/src/main/java/io/personium/plugin/base/auth/AuthPluginLoader.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 public interface AuthPluginLoader {
     /**
      * Instanciate Multiple AuthPlugin.
-     * @return ArrayList of AuthPlugin
+     * @return List of AuthPlugin
      */
     List<AuthPlugin> loadInstances();
 }

--- a/src/main/java/io/personium/plugin/base/auth/AuthPluginLoader.java
+++ b/src/main/java/io/personium/plugin/base/auth/AuthPluginLoader.java
@@ -27,5 +27,5 @@ public interface AuthPluginLoader {
      * Instanciate Multiple AuthPlugin.
      * @return ArrayList of AuthPlugin
      */
-    ArrayList<AuthPlugin> loadInstances();
+    List<AuthPlugin> loadInstances();
 }

--- a/src/main/java/io/personium/plugin/base/auth/AuthPluginUtils.java
+++ b/src/main/java/io/personium/plugin/base/auth/AuthPluginUtils.java
@@ -1,6 +1,7 @@
 /**
- * personium.io
- * Copyright 2017 FUJITSU LIMITED
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/personium/plugin/base/auth/AuthenticatedIdentity.java
+++ b/src/main/java/io/personium/plugin/base/auth/AuthenticatedIdentity.java
@@ -1,6 +1,7 @@
 /**
- * personium.io
- * Copyright 2017 FUJITSU LIMITED
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +19,6 @@ package io.personium.plugin.base.auth;
 
 /**
  * Auth plugin result.
- *
  */
 public class AuthenticatedIdentity {
 

--- a/src/main/java/io/personium/plugin/base/auth/OAuth2Helper.java
+++ b/src/main/java/io/personium/plugin/base/auth/OAuth2Helper.java
@@ -1,6 +1,7 @@
 /**
- * personium.io
- * Copyright 2017 FUJITSU LIMITED
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/personium/plugin/base/utils/EscapeControlCode.java
+++ b/src/main/java/io/personium/plugin/base/utils/EscapeControlCode.java
@@ -1,6 +1,7 @@
 /**
- * personium.io
- * Copyright 2017 FUJITSU LIMITED
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/personium/plugin/base/utils/PluginUtils.java
+++ b/src/main/java/io/personium/plugin/base/utils/PluginUtils.java
@@ -32,7 +32,7 @@ import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.cache.CachingHttpClient;
+import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -234,7 +234,7 @@ public final class PluginUtils {
      * Cacheを効かせるため、ClientをStaticとする. たかだか限定されたURLのbodyを保存するのみであり、
      * 最大キャッシュサイズはCacheConfigクラスで定義された16kbyte程度である. そのため、Staticで持つこととした.
      */
-    private static HttpClient httpClient = new CachingHttpClient();
+    private static HttpClient httpClient = CachingHttpClientBuilder.create().build();
 
     /**
      * HTTPでJSONオブジェクトを取得する処理. Cacheが利用可能であればその値を用いる.

--- a/src/main/java/io/personium/plugin/base/utils/PluginUtils.java
+++ b/src/main/java/io/personium/plugin/base/utils/PluginUtils.java
@@ -1,6 +1,7 @@
 /**
- * personium.io
- * Copyright 2017 FUJITSU LIMITED
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/personium/plugin/base/utils/ProxyUtils.java
+++ b/src/main/java/io/personium/plugin/base/utils/ProxyUtils.java
@@ -1,6 +1,7 @@
 /**
- * personium.io
- * Copyright 2017 FUJITSU LIMITED
+ * Personium
+ * Copyright 2014-2021 Personium Project Authors
+ * - FUJITSU LIMITED
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION

This PR contains below.

### Multiple AuthPlugin Support

To load multiple instances by one class, `AuthPluginLoader` interface is added.
By implementing AuthPluginLoader containing `loadInstances()` , you can load multiple AuthPlugin onto Personium unit.

### some fixes

- modifing headers.
- Replace CachingHttpClient with CachingHttpClientBuilder.
- If properties file is not found, throw exception.